### PR TITLE
Feat: [FN-121] 그룹 내 멤버 조회 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### QueryDSL ###
+/src/main/generated/
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,29 @@ dependencies {
 	testRuntimeOnly 'com.h2database:h2'
 	implementation platform('software.amazon.awssdk:bom:2.20.56')
 	implementation 'software.amazon.awssdk:s3'
+
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
+
+tasks.withType(JavaCompile).configureEach {
+	options.generatedSourceOutputDirectory.set(querydslDir)
+}
+
+sourceSets {
+	main {
+		java {
+			srcDir querydslDir
+		}
+	}
+}
+
+clean.doLast {
+	file(querydslDir).deleteDir()
 }
 
 tasks.named('test') {

--- a/src/main/java/project/flipnote/group/controller/GroupController.java
+++ b/src/main/java/project/flipnote/group/controller/GroupController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import project.flipnote.common.security.dto.AuthPrinciple;
+import project.flipnote.group.model.FindGroupMemberResponse;
+import project.flipnote.group.model.FindGroupMemberResponse;
 import project.flipnote.group.model.GroupCreateRequest;
 import project.flipnote.group.model.GroupCreateResponse;
 import project.flipnote.group.model.GroupDetailResponse;
@@ -53,5 +55,15 @@ public class GroupController {
 		groupService.deleteGroup(authPrinciple, groupId);
 
 		return ResponseEntity.noContent().build();
+	}
+
+	//그룹내 멤버 조회
+	@GetMapping("/{groupId}/members")
+	public ResponseEntity<FindGroupMemberResponse> findGroupMembers(
+		@AuthenticationPrincipal AuthPrinciple authPrinciple,
+		@PathVariable("groupId") Long groupId) {
+		FindGroupMemberResponse res = groupService.findGroupMembers(authPrinciple, groupId);
+
+		return ResponseEntity.ok(res);
 	}
 }

--- a/src/main/java/project/flipnote/group/model/FindGroupMemberResponse.java
+++ b/src/main/java/project/flipnote/group/model/FindGroupMemberResponse.java
@@ -1,0 +1,11 @@
+package project.flipnote.group.model;
+
+import java.util.List;
+
+public record FindGroupMemberResponse(
+	List<GroupMemberInfo> groupMembers
+) {
+	public static FindGroupMemberResponse from(List<GroupMemberInfo> groupMembers) {
+		return new FindGroupMemberResponse(groupMembers);
+	}
+}

--- a/src/main/java/project/flipnote/group/model/GroupMemberInfo.java
+++ b/src/main/java/project/flipnote/group/model/GroupMemberInfo.java
@@ -1,0 +1,14 @@
+package project.flipnote.group.model;
+
+import project.flipnote.group.entity.GroupMemberRole;
+
+public record GroupMemberInfo(
+	Long id,
+	GroupMemberRole role,
+	String name,
+	String profile
+) {
+	public static GroupMemberInfo from(Long id, GroupMemberRole role, String name, String profile) {
+		return new GroupMemberInfo(id, role, name, profile);
+	}
+}

--- a/src/main/java/project/flipnote/group/repository/GroupMemberRepository.java
+++ b/src/main/java/project/flipnote/group/repository/GroupMemberRepository.java
@@ -12,7 +12,7 @@ import project.flipnote.group.entity.GroupMemberRole;
 import project.flipnote.user.entity.UserProfile;
 
 @Repository
-public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>, GroupMemberRepositoryCustom {
 	Optional<GroupMember> findByGroupAndUser(Group group, UserProfile userProfile);
 
 	long countByGroup_Id(Long groupId);
@@ -24,4 +24,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 	long countByGroup_idAndUser_idNot(Long groupId, Long userId);
 
 	List<GroupMember> findByGroupAndRoleIn(Group group, List<GroupMemberRole> roles);
+
+	List<GroupMember> findAllByGroup_Id(Long groupId);
+
 }

--- a/src/main/java/project/flipnote/group/repository/GroupMemberRepository.java
+++ b/src/main/java/project/flipnote/group/repository/GroupMemberRepository.java
@@ -25,6 +25,5 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long>,
 
 	List<GroupMember> findByGroupAndRoleIn(Group group, List<GroupMemberRole> roles);
 
-	List<GroupMember> findAllByGroup_Id(Long groupId);
-
+	boolean existsByGroup_IdAndUser_Id(Long groupId, Long id);
 }

--- a/src/main/java/project/flipnote/group/repository/GroupMemberRepositoryCustom.java
+++ b/src/main/java/project/flipnote/group/repository/GroupMemberRepositoryCustom.java
@@ -1,0 +1,9 @@
+package project.flipnote.group.repository;
+
+import java.util.List;
+
+import project.flipnote.group.model.GroupMemberInfo;
+
+public interface GroupMemberRepositoryCustom {
+	List<GroupMemberInfo> findGroupMembers(Long groupId);
+}

--- a/src/main/java/project/flipnote/group/repository/GroupMemberRepositoryImpl.java
+++ b/src/main/java/project/flipnote/group/repository/GroupMemberRepositoryImpl.java
@@ -1,0 +1,36 @@
+package project.flipnote.group.repository;
+
+import java.util.List;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import project.flipnote.group.entity.QGroupMember;
+import project.flipnote.group.model.GroupMemberInfo;
+import project.flipnote.user.entity.QUserProfile;
+
+@RequiredArgsConstructor
+public class GroupMemberRepositoryImpl{
+
+	private final JPAQueryFactory queryFactory;
+
+	QUserProfile userProfile = QUserProfile.userProfile;
+	QGroupMember groupMember = QGroupMember.groupMember;
+
+	public List<GroupMemberInfo> findGroupMembers(Long groupId) {
+		return queryFactory.select(Projections.constructor(
+				GroupMemberInfo.class,
+				userProfile.id,
+				groupMember.role,
+				userProfile.name,
+				userProfile.profileImageUrl
+			))
+			.from(groupMember)
+			.join(groupMember.user, userProfile)
+			.where(groupMember.group.id.eq(groupId))
+			.fetch();
+	}
+
+}

--- a/src/main/java/project/flipnote/group/repository/GroupMemberRepositoryImpl.java
+++ b/src/main/java/project/flipnote/group/repository/GroupMemberRepositoryImpl.java
@@ -12,7 +12,7 @@ import project.flipnote.group.model.GroupMemberInfo;
 import project.flipnote.user.entity.QUserProfile;
 
 @RequiredArgsConstructor
-public class GroupMemberRepositoryImpl{
+public class GroupMemberRepositoryImpl implements GroupMemberRepositoryCustom {
 
 	private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/project/flipnote/group/repository/GroupRepository.java
+++ b/src/main/java/project/flipnote/group/repository/GroupRepository.java
@@ -22,4 +22,6 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
 
 	@Query("SELECT g.name FROM Group g WHERE g.id = :id")
 	Optional<String> findGroupNameById(@Param("id") Long id);
+
+	boolean existsByIdAndDeletedAtIsNull(Long groupId);
 }

--- a/src/main/java/project/flipnote/group/service/GroupService.java
+++ b/src/main/java/project/flipnote/group/service/GroupService.java
@@ -17,9 +17,11 @@ import project.flipnote.group.entity.GroupPermission;
 import project.flipnote.group.entity.GroupPermissionStatus;
 import project.flipnote.group.entity.GroupRolePermission;
 import project.flipnote.group.exception.GroupErrorCode;
+import project.flipnote.group.model.FindGroupMemberResponse;
 import project.flipnote.group.model.GroupCreateRequest;
 import project.flipnote.group.model.GroupCreateResponse;
 import project.flipnote.group.model.GroupDetailResponse;
+import project.flipnote.group.model.GroupMemberInfo;
 import project.flipnote.group.repository.GroupMemberRepository;
 import project.flipnote.group.repository.GroupPermissionRepository;
 import project.flipnote.group.repository.GroupRepository;
@@ -50,16 +52,25 @@ public class GroupService {
 			() -> new BizException(UserErrorCode.USER_NOT_FOUND)
 		);
 	}
-
+	
 	/*
-	그룹 내 유저 조회
+	그룹 내 유저 검증
 	 */
-	public GroupMember validateGroupInUser(UserProfile user, Long groupId) {
-		return groupMemberRepository.findByGroup_IdAndUser_Id(groupId, user.getId()).orElseThrow(
+	public void validateGroupInUser(UserProfile user, Long groupId) {
+		groupMemberRepository.findByGroup_IdAndUser_Id(groupId, user.getId()).orElseThrow(
 			() -> new BizException(GroupJoinErrorCode.USER_NOT_IN_GROUP)
 		);
 	}
 
+	/*
+	그룹 내 유저 조회
+	 */
+	public GroupMember getGroupMember(UserProfile user, Long groupId) {
+		return groupMemberRepository.findByGroup_IdAndUser_Id(groupId, user.getId()).orElseThrow(
+			() -> new BizException(GroupJoinErrorCode.USER_NOT_IN_GROUP)
+		);
+	}
+	
 	/*
 	그룹 조회
 	 */
@@ -174,6 +185,14 @@ public class GroupService {
 		}
 		return true;
 	}
+	
+	/*
+	그룹 내 모든 멤버리스트 조회
+	 */
+	private List<GroupMemberInfo> findGroupMembers(Long groupId) {
+		//각 그룹멤버의 id를 가지고 유저를 찾고 유저명, 권한, 등등 가져오기
+		return groupMemberRepository.findGroupMembers(groupId);
+	}
 
 	/*
 	그룹 상세 정보 조회
@@ -202,7 +221,7 @@ public class GroupService {
 		UserProfile user = validateUser(authPrinciple);
 
 		//3. 그룹 내 유저 조회
-		GroupMember groupMember = validateGroupInUser(user, groupId);
+		GroupMember groupMember = getGroupMember(user, groupId);
 
 		//4. 유저 권환 조회
 		if (!groupMember.getRole().equals(GroupMemberRole.OWNER)) {
@@ -221,5 +240,21 @@ public class GroupService {
 	public String findGroupName(Long groupId) {
 		return groupRepository.findGroupNameById(groupId)
 			.orElseThrow(() -> new BizException(GroupErrorCode.GROUP_NOT_FOUND));
+	}
+
+	public FindGroupMemberResponse findGroupMembers(AuthPrinciple authPrinciple, Long groupId) {
+		//1. 그룹 조회
+		Group group = validateGroup(groupId);
+
+		//2. 유저 조회
+		UserProfile user = validateUser(authPrinciple);
+
+		//3. 그룹 내 유저 조회
+		validateGroupInUser(user, groupId);
+
+		//4. 그룹 내 모든 유저 조회
+		List<GroupMemberInfo> groupMembers = findGroupMembers(groupId);
+
+		return FindGroupMemberResponse.from(groupMembers);
 	}
 }

--- a/src/main/java/project/flipnote/group/service/GroupService.java
+++ b/src/main/java/project/flipnote/group/service/GroupService.java
@@ -61,9 +61,9 @@ public class GroupService {
 	그룹 내 유저 검증
 	 */
 	public void validateGroupInUser(UserProfile user, Long groupId) {
-		groupMemberRepository.findByGroup_IdAndUser_Id(groupId, user.getId()).orElseThrow(
-			() -> new BizException(GroupJoinErrorCode.USER_NOT_IN_GROUP)
-		);
+		if(!groupMemberRepository.existsByGroup_IdAndUser_Id(groupId, user.getId())) {
+			throw new BizException(GroupJoinErrorCode.USER_NOT_IN_GROUP);
+		}
 	}
 
 	/*
@@ -76,9 +76,18 @@ public class GroupService {
 	}
 
 	/*
+	그룹 검증
+	 */
+	public void validateGroup(Long groupId) {
+		if(!groupRepository.existsByIdAndDeletedAtIsNull(groupId)) {
+			throw new BizException(GroupErrorCode.GROUP_NOT_FOUND);
+		}
+	}
+
+	/*
 	그룹 조회
 	 */
-	public Group validateGroup(Long groupId) {
+	public Group getGroup(Long groupId) {
 		return groupRepository.findByIdAndDeletedAtIsNull(groupId).orElseThrow(
 			() -> new BizException(GroupErrorCode.GROUP_NOT_FOUND)
 		);
@@ -196,8 +205,8 @@ public class GroupService {
 		//2. 인원수 검증
 		validateMaxMember(req.maxMember());
 
-		//3. 그룹 가져오기
-		Group group = validateGroup(groupId);
+		//3. 그룹 조회
+		validateGroup(groupId);
 
 		//4. 그룹 내 유저 조회
 		GroupMember groupMember = getGroupMember(user, groupId);
@@ -237,7 +246,7 @@ public class GroupService {
 	public GroupDetailResponse findGroupDetail(AuthPrinciple authPrinciple, Long groupId) {
 
 		//1. 그룹 조회
-		Group group = validateGroup(groupId);
+		Group group = getGroup(groupId);
 
 		//2. 유저 조회
 		UserProfile user = validateUser(authPrinciple);
@@ -252,7 +261,7 @@ public class GroupService {
 	@Transactional
 	public void deleteGroup(AuthPrinciple authPrinciple, Long groupId) {
 		//1. 그룹 조회
-		Group group = validateGroup(groupId);
+		Group group = getGroup(groupId);
 
 		//2. 유저 조회
 		UserProfile user = validateUser(authPrinciple);
@@ -274,14 +283,16 @@ public class GroupService {
 
 	}
 
+	//그룹이름 찾는 메서드
 	public String findGroupName(Long groupId) {
 		return groupRepository.findGroupNameById(groupId)
 			.orElseThrow(() -> new BizException(GroupErrorCode.GROUP_NOT_FOUND));
 	}
 
+	//그룹 내 멤버 조회 메서드
 	public FindGroupMemberResponse findGroupMembers(AuthPrinciple authPrinciple, Long groupId) {
-		//1. 그룹 조회
-		Group group = validateGroup(groupId);
+		//1. 그룹 검증
+		validateGroup(groupId);
 
 		//2. 유저 조회
 		UserProfile user = validateUser(authPrinciple);

--- a/src/main/java/project/flipnote/infra/config/QuerydslConfig.java
+++ b/src/main/java/project/flipnote/infra/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package project.flipnote.infra.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+	private final EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/test/java/project/flipnote/group/service/GroupServiceTest.java
+++ b/src/test/java/project/flipnote/group/service/GroupServiceTest.java
@@ -160,6 +160,7 @@ class GroupServiceTest {
 			.maxMember(100)
 			.imageUrl("www.~~~")
 			.build();
+		ReflectionTestUtils.setField(group, "id", 1L);
 
 		GroupMember groupMember = GroupMember.builder()
 			.group(group)
@@ -167,8 +168,8 @@ class GroupServiceTest {
 			.role(GroupMemberRole.MEMBER)
 			.build();
 
-		given(groupRepository.findByIdAndDeletedAtIsNull(any())).willReturn(Optional.of(group));
-		given(groupMemberRepository.findByGroup_IdAndUser_Id(any(), any())).willReturn(Optional.of(groupMember));
+		given(groupRepository.findByIdAndDeletedAtIsNull(group.getId())).willReturn(Optional.of(group));
+		given(groupMemberRepository.existsByGroup_IdAndUser_Id(any(), any())).willReturn(true);
 		// 사용자 검증 로직
 		given(userProfileRepository.findByIdAndStatus(userProfile.getId(), UserStatus.ACTIVE))
 			.willReturn(Optional.of(userProfile));
@@ -192,10 +193,11 @@ class GroupServiceTest {
 			.maxMember(100)
 			.imageUrl("www.~~~")
 			.build();
+		ReflectionTestUtils.setField(group, "id", 1L);
 
-		given(groupRepository.findByIdAndDeletedAtIsNull(any())).willReturn(Optional.ofNullable(group));
+		given(groupRepository.findByIdAndDeletedAtIsNull(group.getId())).willReturn(Optional.of(group));
 		given(userProfileRepository.findByIdAndStatus(userProfile.getId(), UserStatus.ACTIVE)).willReturn(Optional.ofNullable(userProfile));
-		given(groupMemberRepository.findByGroup_IdAndUser_Id(any(), any())).willReturn(Optional.empty());
+		given(groupMemberRepository.existsByGroup_IdAndUser_Id(any(), any())).willReturn(false);
 
 	    //when
 		BizException exception =
@@ -344,16 +346,16 @@ class GroupServiceTest {
 
 		List<GroupMemberInfo> groupMembers = List.of(GroupMemberInfo.from(userProfile.getId(), groupMember.getRole(), userProfile.getName(), userProfile.getProfileImageUrl()));
 
-		given(groupRepository.findByIdAndDeletedAtIsNull(group.getId())).willReturn(Optional.of(group));
+		given(groupRepository.existsByIdAndDeletedAtIsNull(group.getId())).willReturn(true);
 		given(userProfileRepository.findByIdAndStatus(userProfile.getId(), UserStatus.ACTIVE)).willReturn(Optional.of(userProfile));
-		given(groupMemberRepository.findByGroup_IdAndUser_Id(group.getId(),userProfile.getId())).willReturn(Optional.of(groupMember));
+		given(groupMemberRepository.existsByGroup_IdAndUser_Id(group.getId(),userProfile.getId())).willReturn(true);
 		given(groupMemberRepository.findGroupMembers(group.getId())).willReturn(groupMembers);
 	    //when
 		FindGroupMemberResponse res = groupService.findGroupMembers(authPrinciple, group.getId());
 		//then
 		assertEquals(1, res.groupMembers().size());
 		assertEquals(userProfile.getId(), res.groupMembers().get(0).id());
-		then(groupRepository).should().findByIdAndDeletedAtIsNull(group.getId());
+		then(groupRepository).should().existsByIdAndDeletedAtIsNull(group.getId());
 		then(groupMemberRepository).should().findGroupMembers(group.getId());
 	}
 
@@ -380,7 +382,7 @@ class GroupServiceTest {
 
 		GroupPutRequest req = new GroupPutRequest("그룹1", Category.ENGLISH, "설명1", true, true, 100, "www.~~");
 
-		given(groupRepository.findByIdAndDeletedAtIsNull(group.getId())).willReturn(Optional.of(group));
+		given(groupRepository.existsByIdAndDeletedAtIsNull(any())).willReturn(true);
 		given(userProfileRepository.findByIdAndStatus(userProfile.getId(), UserStatus.ACTIVE)).willReturn(Optional.of(userProfile));
 		given(groupMemberRepository.findByGroup_IdAndUser_Id(group.getId(),userProfile.getId())).willReturn(Optional.of(groupMember));
 
@@ -396,8 +398,8 @@ class GroupServiceTest {
 		GroupPutResponse res = groupService.changeGroup(authPrinciple, req, group.getId());
 
 		//then
-		assertEquals(req.name(), group.getName());
-		assertEquals(req.category(), group.getCategory());
+		assertEquals(req.name(), res.name());
+		assertEquals(req.category(), res.category());
 	}
 
 	@Test
@@ -423,7 +425,7 @@ class GroupServiceTest {
 
 		GroupPutRequest req = new GroupPutRequest("그룹1", Category.ENGLISH, "설명1", true, true, 100, "www.~~");
 
-		given(groupRepository.findByIdAndDeletedAtIsNull(group.getId())).willReturn(Optional.of(group));
+		given(groupRepository.existsByIdAndDeletedAtIsNull(any())).willReturn(true);
 		given(userProfileRepository.findByIdAndStatus(userProfile.getId(), UserStatus.ACTIVE)).willReturn(Optional.of(userProfile));
 		given(groupMemberRepository.findByGroup_IdAndUser_Id(group.getId(),userProfile.getId())).willReturn(Optional.of(groupMember));
 		//when
@@ -457,7 +459,7 @@ class GroupServiceTest {
 
 		GroupPutRequest req = new GroupPutRequest("그룹1", Category.ENGLISH, "설명1", true, true, 50, "www.~~");
 
-		given(groupRepository.findByIdAndDeletedAtIsNull(group.getId())).willReturn(Optional.of(group));
+		given(groupRepository.existsByIdAndDeletedAtIsNull(any())).willReturn(true);
 		given(userProfileRepository.findByIdAndStatus(userProfile.getId(), UserStatus.ACTIVE)).willReturn(Optional.of(userProfile));
 		given(groupMemberRepository.findByGroup_IdAndUser_Id(group.getId(),userProfile.getId())).willReturn(Optional.of(groupMember));
 

--- a/src/test/java/project/flipnote/group/service/GroupServiceTest.java
+++ b/src/test/java/project/flipnote/group/service/GroupServiceTest.java
@@ -30,10 +30,13 @@ import project.flipnote.group.entity.GroupMemberRole;
 import project.flipnote.group.entity.GroupPermission;
 import project.flipnote.group.entity.GroupPermissionStatus;
 import project.flipnote.group.exception.GroupErrorCode;
+import project.flipnote.group.model.FindGroupMemberResponse;
 import project.flipnote.group.model.GroupCreateRequest;
 import project.flipnote.group.model.GroupCreateResponse;
 import project.flipnote.group.model.GroupDetailResponse;
+import project.flipnote.group.model.GroupMemberInfo;
 import project.flipnote.group.repository.GroupMemberRepository;
+import project.flipnote.group.repository.GroupMemberRepositoryImpl;
 import project.flipnote.group.repository.GroupPermissionRepository;
 import project.flipnote.group.repository.GroupRepository;
 import project.flipnote.group.repository.GroupRolePermissionRepository;
@@ -66,6 +69,9 @@ class GroupServiceTest {
 
 	@Mock
 	GroupMemberRepository groupMemberRepository;
+
+	@Mock
+	GroupMemberRepositoryImpl groupMemberRepositoryImpl;
 
 	UserProfile userProfile;
 	AuthPrinciple authPrinciple;
@@ -288,6 +294,7 @@ class GroupServiceTest {
 			.maxMember(100)
 			.imageUrl("www.~~~")
 			.build();
+		ReflectionTestUtils.setField(group, "id", 1L);
 
 		GroupMember groupMember = GroupMember.builder()
 			.group(group)
@@ -305,5 +312,41 @@ class GroupServiceTest {
 			assertThrows(BizException.class, () -> groupService.deleteGroup(authPrinciple, group.getId()));
 
 		assertEquals(GroupErrorCode.OTHER_USER_EXIST_IN_GROUP, exception.getErrorCode());
+	}
+
+	@Test
+	public void 그룹_멤버조회_성공() throws Exception {
+	    //given
+		Group group = Group.builder()
+			.name("그룹1")
+			.category(Category.IT)
+			.description("설명1")
+			.publicVisible(true)
+			.applicationRequired(true)
+			.maxMember(100)
+			.imageUrl("www.~~~")
+			.build();
+		ReflectionTestUtils.setField(group, "id", 1L);
+
+		GroupMember groupMember = GroupMember.builder()
+			.group(group)
+			.role(GroupMemberRole.OWNER)
+			.user(userProfile)
+			.build();
+		ReflectionTestUtils.setField(groupMember, "id", 1L);
+
+		List<GroupMemberInfo> groupMembers = List.of(GroupMemberInfo.from(userProfile.getId(), groupMember.getRole(), userProfile.getName(), userProfile.getProfileImageUrl()));
+
+		given(groupRepository.findByIdAndDeletedAtIsNull(group.getId())).willReturn(Optional.of(group));
+		given(userProfileRepository.findByIdAndStatus(userProfile.getId(), UserStatus.ACTIVE)).willReturn(Optional.of(userProfile));
+		given(groupMemberRepository.findByGroup_IdAndUser_Id(group.getId(),userProfile.getId())).willReturn(Optional.of(groupMember));
+		given(groupMemberRepository.findGroupMembers(group.getId())).willReturn(groupMembers);
+	    //when
+		FindGroupMemberResponse res = groupService.findGroupMembers(authPrinciple, group.getId());
+		//then
+		assertEquals(1, res.groupMembers().size());
+		assertEquals(userProfile.getId(), res.groupMembers().get(0).id());
+		then(groupRepository).should().findByIdAndDeletedAtIsNull(group.getId());
+		then(groupMemberRepository).should().findGroupMembers(group.getId());
 	}
 }


### PR DESCRIPTION
## 📝 변경 내용

---

## ✅ 체크리스트

- [X] 코드가 정상적으로 동작함
- [X] 테스트 코드 통과함
- [X] 문서(README 등)를 최신화함
- [X] 코드 스타일 가이드 준수

---

## 💬 기타 참고 사항

<!-- 리뷰어에게 추가로 알리고 싶은 내용, 테스트 방법 등 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 그룹 멤버 조회 API 추가: GET /v1/groups/{groupId}/members. 멤버 ID, 역할, 이름, 프로필 정보를 반환합니다.
  - 그룹 멤버 목록 응답 DTO 및 관련 서비스 흐름 추가로 멤버 목록 조회 지원.

- Chores
  - QueryDSL 도입 및 빌드 설정 추가로 코드 생성 소스 경로 관리 및 정리 자동화.
  - 생성된 소스 디렉터리 무시(.gitignore) 항목 추가.

- 테스트
  - 그룹 멤버 조회 성공 시나리오 테스트 추가로 안정성 강화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->