### PR TITLE
Feat: 특정 그룹의 카드셋 조회 API 구현

### DIFF
--- a/src/main/java/project/flipnote/cardset/controller/GroupCardSetController.java
+++ b/src/main/java/project/flipnote/cardset/controller/GroupCardSetController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -15,10 +16,13 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import project.flipnote.cardset.controller.docs.GroupCardSetControllerDocs;
 import project.flipnote.cardset.model.CardSetDetailResponse;
+import project.flipnote.cardset.model.CardSetSearchRequest;
+import project.flipnote.cardset.model.CardSetSummaryResponse;
 import project.flipnote.cardset.model.CardSetUpdateRequest;
 import project.flipnote.cardset.model.CreateCardSetRequest;
 import project.flipnote.cardset.model.CreateCardSetResponse;
 import project.flipnote.cardset.service.CardSetService;
+import project.flipnote.common.model.response.PagingResponse;
 import project.flipnote.common.security.dto.AuthPrinciple;
 
 @RequiredArgsConstructor
@@ -62,4 +66,13 @@ public class GroupCardSetController implements GroupCardSetControllerDocs {
 		return ResponseEntity.ok(res);
 	}
 
+	@GetMapping
+	public ResponseEntity<PagingResponse<CardSetSummaryResponse>> getCardSets(
+		@PathVariable("groupId") Long groupId,
+		@Valid @ModelAttribute CardSetSearchRequest req
+	) {
+		PagingResponse<CardSetSummaryResponse> res = cardSetService.getCardSets(groupId, req);
+
+		return ResponseEntity.ok(res);
+	}
 }

--- a/src/main/java/project/flipnote/cardset/model/CardSetSummaryResponse.java
+++ b/src/main/java/project/flipnote/cardset/model/CardSetSummaryResponse.java
@@ -1,7 +1,5 @@
 package project.flipnote.cardset.model;
 
-import project.flipnote.cardset.entity.CardSet;
-
 public record CardSetSummaryResponse(
 	Long cardSetId,
 	Long groupId,

--- a/src/main/java/project/flipnote/cardset/repository/CardSetRepositoryCustom.java
+++ b/src/main/java/project/flipnote/cardset/repository/CardSetRepositoryCustom.java
@@ -20,7 +20,7 @@ public interface CardSetRepositoryCustom {
 	List<CardSetInfo> findAllByIdWithImageRefId(Set<Long> cardSets);
 
 	Page<CardSetInfo> searchByGroupIdAndNameContainingAndCategory(
-		long groupId,
+		Long groupId,
 		String name,
 		Category category,
 		Pageable pageable

--- a/src/main/java/project/flipnote/cardset/repository/CardSetRepositoryCustom.java
+++ b/src/main/java/project/flipnote/cardset/repository/CardSetRepositoryCustom.java
@@ -6,7 +6,6 @@ import java.util.Set;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import project.flipnote.cardset.entity.CardSet;
 import project.flipnote.cardset.model.CardSetInfo;
 import project.flipnote.group.entity.Category;
 
@@ -19,4 +18,11 @@ public interface CardSetRepositoryCustom {
 	);
 
 	List<CardSetInfo> findAllByIdWithImageRefId(Set<Long> cardSets);
+
+	Page<CardSetInfo> searchByGroupIdAndNameContainingAndCategory(
+		long groupId,
+		String name,
+		Category category,
+		Pageable pageable
+	);
 }

--- a/src/main/java/project/flipnote/cardset/repository/CardSetRepositoryCustomImpl.java
+++ b/src/main/java/project/flipnote/cardset/repository/CardSetRepositoryCustomImpl.java
@@ -46,71 +46,7 @@ public class CardSetRepositoryCustomImpl implements CardSetRepositoryCustom {
 		Category category,
 		Pageable pageable
 	) {
-		List<OrderSpecifier<?>> orders = new ArrayList<>();
-
-		boolean useMetadata = false;
-		boolean hasIdSort = false;
-		for (Sort.Order order : pageable.getSort()) {
-			CardSetSortField sortField = null;
-			try {
-				sortField = CardSetSortField.valueOf(order.getProperty());
-			} catch (IllegalArgumentException iae) {
-				log.warn(
-					"Unknown sort property: {}. Valid values are {}",
-					order.getProperty(), Arrays.toString(CardSetSortField.values()), iae
-				);
-			}
-			if (sortField == CardSetSortField.LIKE) {
-				orders.add(toOrderSpecifier(cardSetMetadata.likeCount, order));
-				useMetadata = true;
-			} else if (sortField == CardSetSortField.BOOKMARK) {
-				orders.add(toOrderSpecifier(cardSetMetadata.bookmarkCount, order));
-				useMetadata = true;
-			} else {
-				orders.add(toOrderSpecifier(cardSet.id, order));
-				hasIdSort = true;
-			}
-		}
-
-		if (!hasIdSort) {
-			orders.add(cardSet.id.desc());
-		}
-
-		JPAQuery<CardSetInfo> selectQuery = queryFactory
-			.select(
-				Projections.constructor(
-					CardSetInfo.class,
-					cardSet,
-					cardSet.group,
-					cardSet.name,
-					cardSet.category,
-					cardSet.hashtag,
-					cardSet.imageUrl,
-					imageRef.id
-				))
-			.from(cardSet)
-			.where(buildCardSetSearchFilterConditions(null, name, category))
-			.leftJoin(imageRef)
-			.on(imageRef.referenceType.eq(ReferenceType.CARD_SET)
-				.and(imageRef.referenceId.eq(cardSet.id)));
-
-		if (useMetadata) {
-			selectQuery.leftJoin(cardSetMetadata).on(cardSet.id.eq(cardSetMetadata.id));
-		}
-
-		List<CardSetInfo> content = selectQuery
-			.orderBy(orders.toArray(new OrderSpecifier[0]))
-			.offset(pageable.getOffset())
-			.limit(pageable.getPageSize())
-			.fetch();
-
-		Long total = queryFactory
-			.select(cardSet.count())
-			.from(cardSet)
-			.where(buildCardSetSearchFilterConditions(null, name, category))
-			.fetchOne();
-
-		return new PageImpl<>(content, pageable, total != null ? total : 0L);
+		return searchByGroupIdAndNameContainingAndCategory(null, name, category, pageable);
 	}
 
 	public List<CardSetInfo> findAllByIdWithImageRefId(Set<Long> cardSets) {
@@ -135,7 +71,7 @@ public class CardSetRepositoryCustomImpl implements CardSetRepositoryCustom {
 
 	@Override
 	public Page<CardSetInfo> searchByGroupIdAndNameContainingAndCategory(
-		long groupId,
+		Long groupId,
 		String name,
 		Category category,
 		Pageable pageable

--- a/src/main/java/project/flipnote/cardset/repository/CardSetRepositoryCustomImpl.java
+++ b/src/main/java/project/flipnote/cardset/repository/CardSetRepositoryCustomImpl.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import org.checkerframework.checker.units.qual.C;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -22,7 +21,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import project.flipnote.cardset.entity.CardSet;
 import project.flipnote.cardset.entity.QCardSet;
 import project.flipnote.cardset.entity.QCardSetMetadata;
 import project.flipnote.cardset.model.CardSetInfo;
@@ -91,7 +89,7 @@ public class CardSetRepositoryCustomImpl implements CardSetRepositoryCustom {
 					imageRef.id
 				))
 			.from(cardSet)
-			.where(buildCardSetSearchFilterConditions(name, category))
+			.where(buildCardSetSearchFilterConditions(null, name, category))
 			.leftJoin(imageRef)
 			.on(imageRef.referenceType.eq(ReferenceType.CARD_SET)
 				.and(imageRef.referenceId.eq(cardSet.id)));
@@ -109,7 +107,7 @@ public class CardSetRepositoryCustomImpl implements CardSetRepositoryCustom {
 		Long total = queryFactory
 			.select(cardSet.count())
 			.from(cardSet)
-			.where(buildCardSetSearchFilterConditions(name, category))
+			.where(buildCardSetSearchFilterConditions(null, name, category))
 			.fetchOne();
 
 		return new PageImpl<>(content, pageable, total != null ? total : 0L);
@@ -135,6 +133,80 @@ public class CardSetRepositoryCustomImpl implements CardSetRepositoryCustom {
 			.fetch();
 	}
 
+	@Override
+	public Page<CardSetInfo> searchByGroupIdAndNameContainingAndCategory(
+		long groupId,
+		String name,
+		Category category,
+		Pageable pageable
+	) {
+		List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+		boolean useMetadata = false;
+		boolean hasIdSort = false;
+		for (Sort.Order order : pageable.getSort()) {
+			CardSetSortField sortField = null;
+			try {
+				sortField = CardSetSortField.valueOf(order.getProperty());
+			} catch (IllegalArgumentException iae) {
+				log.warn(
+					"Unknown sort property: {}. Valid values are {}",
+					order.getProperty(), Arrays.toString(CardSetSortField.values()), iae
+				);
+			}
+			if (sortField == CardSetSortField.LIKE) {
+				orders.add(toOrderSpecifier(cardSetMetadata.likeCount, order));
+				useMetadata = true;
+			} else if (sortField == CardSetSortField.BOOKMARK) {
+				orders.add(toOrderSpecifier(cardSetMetadata.bookmarkCount, order));
+				useMetadata = true;
+			} else {
+				orders.add(toOrderSpecifier(cardSet.id, order));
+				hasIdSort = true;
+			}
+		}
+
+		if (!hasIdSort) {
+			orders.add(cardSet.id.desc());
+		}
+
+		JPAQuery<CardSetInfo> selectQuery = queryFactory
+			.select(
+				Projections.constructor(
+					CardSetInfo.class,
+					cardSet,
+					cardSet.group,
+					cardSet.name,
+					cardSet.category,
+					cardSet.hashtag,
+					cardSet.imageUrl,
+					imageRef.id
+				))
+			.from(cardSet)
+			.where(buildCardSetSearchFilterConditions(groupId, name, category))
+			.leftJoin(imageRef)
+			.on(imageRef.referenceType.eq(ReferenceType.CARD_SET)
+				.and(imageRef.referenceId.eq(cardSet.id)));
+
+		if (useMetadata) {
+			selectQuery.leftJoin(cardSetMetadata).on(cardSet.id.eq(cardSetMetadata.id));
+		}
+
+		List<CardSetInfo> content = selectQuery
+			.orderBy(orders.toArray(new OrderSpecifier[0]))
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		Long total = queryFactory
+			.select(cardSet.count())
+			.from(cardSet)
+			.where(buildCardSetSearchFilterConditions(groupId, name, category))
+			.fetchOne();
+
+		return new PageImpl<>(content, pageable, total != null ? total : 0L);
+	}
+
 	private OrderSpecifier<?> toOrderSpecifier(
 		NumberPath<?> path,
 		Sort.Order order
@@ -150,8 +222,13 @@ public class CardSetRepositoryCustomImpl implements CardSetRepositoryCustom {
 		return category == null ? null : cardSet.category.eq(category);
 	}
 
-	private BooleanExpression[] buildCardSetSearchFilterConditions(String name, Category category) {
-		return new BooleanExpression[]{
+	private BooleanExpression groupIdEquals(Long groupId) {
+		return groupId == null ? null : cardSet.group.id.eq(groupId);
+	}
+
+	private BooleanExpression[] buildCardSetSearchFilterConditions(Long groupId, String name, Category category) {
+		return new BooleanExpression[] {
+			groupIdEquals(groupId),
 			nameContains(name),
 			categoryEquals(category),
 			cardSet.publicVisible.isTrue()

--- a/src/main/java/project/flipnote/cardset/service/CardSetService.java
+++ b/src/main/java/project/flipnote/cardset/service/CardSetService.java
@@ -34,11 +34,10 @@ import project.flipnote.group.entity.Group;
 import project.flipnote.group.exception.GroupErrorCode;
 import project.flipnote.group.repository.GroupMemberRepository;
 import project.flipnote.group.repository.GroupRepository;
-import project.flipnote.image.entity.Image;
+import project.flipnote.group.service.GroupService;
 import project.flipnote.image.entity.ImageMeta;
 import project.flipnote.image.entity.ImageRef;
 import project.flipnote.image.entity.ReferenceType;
-import project.flipnote.image.exception.ImageErrorCode;
 import project.flipnote.image.service.ImageRefService;
 import project.flipnote.image.service.ImageService;
 import project.flipnote.user.entity.UserProfile;
@@ -61,6 +60,7 @@ public class CardSetService {
 	private final CardSetMetadataRepository cardSetMetadataRepository;
 	private final ImageService imageService;
 	private final ImageRefService imageRefService;
+	private final GroupService groupService;
 
 	@Value("${image.default.cardSet}")
 	private String defaultCardSetImage;
@@ -336,6 +336,8 @@ public class CardSetService {
 	 * @author 윤정환
 	 */
 	public PagingResponse<CardSetSummaryResponse> getCardSets(long groupId, CardSetSearchRequest req) {
+		groupService.validateGroupExists(groupId);
+
 		// TODO: Projection 튜닝 필요
 		Page<CardSetInfo> cardSetPage = cardSetRepository.searchByGroupIdAndNameContainingAndCategory(
 			groupId, req.getKeyword(), Category.from(req.getCategory()), req.getPageRequest()

--- a/src/main/java/project/flipnote/cardset/service/CardSetService.java
+++ b/src/main/java/project/flipnote/cardset/service/CardSetService.java
@@ -326,4 +326,23 @@ public class CardSetService {
 	public void decrementBookmarkCount(List<Long> cardSetIds) {
 		cardSetMetadataRepository.decrementBookmarkCount(cardSetIds);
 	}
+
+	/**
+	 * 특정 그룹의 카드셋 목록을 페이지 단위로 조회
+	 *
+	 * @param groupId 조회할 그룹의 ID
+	 * @param req 조회 조건 및 페이징 정보를 포함한 요청 DTO
+	 * @return 페이지 단위로 조회된 카드셋 목록
+	 * @author 윤정환
+	 */
+	public PagingResponse<CardSetSummaryResponse> getCardSets(long groupId, CardSetSearchRequest req) {
+		// TODO: Projection 튜닝 필요
+		Page<CardSetInfo> cardSetPage = cardSetRepository.searchByGroupIdAndNameContainingAndCategory(
+			groupId, req.getKeyword(), Category.from(req.getCategory()), req.getPageRequest()
+		);
+
+		Page<CardSetSummaryResponse> res = cardSetPage.map(CardSetSummaryResponse::from);
+
+		return PagingResponse.from(res);
+	}
 }

--- a/src/main/java/project/flipnote/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/project/flipnote/common/exception/GlobalExceptionHandler.java
@@ -49,7 +49,8 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MissingServletRequestParameterException.class)
 	public ResponseEntity<String> handleMissingServletRequestParameter(
-		MissingServletRequestParameterException exception) {
+		MissingServletRequestParameterException exception
+	) {
 		String missingParam = exception.getParameterName();
 		String message = String.format("필수 파라미터 '%s'가 없습니다.", missingParam);
 		return ResponseEntity.badRequest().body(message);

--- a/src/main/java/project/flipnote/group/service/GroupService.java
+++ b/src/main/java/project/flipnote/group/service/GroupService.java
@@ -38,11 +38,9 @@ import project.flipnote.group.repository.GroupPermissionRepository;
 import project.flipnote.group.repository.GroupRepository;
 import project.flipnote.group.repository.GroupRolePermissionRepository;
 import project.flipnote.groupjoin.exception.GroupJoinErrorCode;
-import project.flipnote.image.entity.Image;
 import project.flipnote.image.entity.ImageMeta;
 import project.flipnote.image.entity.ImageRef;
 import project.flipnote.image.entity.ReferenceType;
-import project.flipnote.image.exception.ImageErrorCode;
 import project.flipnote.image.service.ImageRefService;
 import project.flipnote.image.service.ImageService;
 import project.flipnote.user.entity.UserProfile;
@@ -446,6 +444,19 @@ public class GroupService {
 			user.getId());
 
 		return createGroupInfoCursorPagingResponse(req, groups);
+	}
+
+	/**
+	 * 지정된 그룹 ID가 존재하는지 검사합니다.
+	 *
+	 * @param groupId 존재 여부를 확인할 그룹의 ID
+	 * @throws BizException 그룹이 존재하지 않을 경우 발생
+	 * @author 윤정환
+	 */
+	public void validateGroupExists(Long groupId) {
+		if (!groupRepository.existsById(groupId)) {
+			throw new BizException(GroupErrorCode.GROUP_NOT_FOUND);
+		}
 	}
 
 	//리스트 조회시 response 생성


### PR DESCRIPTION
## 📝 변경 내용

---

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [ ] 테스트 코드 통과함
- [x] 문서(README 등)를 최신화함
- [x] 코드 스타일 가이드 준수

---

## 💬 기타 참고 사항

<!-- 리뷰어에게 추가로 알리고 싶은 내용, 테스트 방법 등 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 그룹별 카드셋 조회 API 추가 — 그룹 ID로 카드셋 검색, 키워드·카테고리 필터 및 페이지네이션 지원
  * 그룹 존재 검증 추가로 잘못된 그룹 요청에 대한 명확한 오류 처리

* **버그 픽스 / 개선**
  * 그룹 범위 기반 검색의 정확도 및 정렬/페이징 동작 개선

* **스타일**
  * 예외 처리 관련 코드 포맷 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->